### PR TITLE
Add start button in rules screen

### DIFF
--- a/app/src/main/java/com/example/appconejitos/RulesActivity.java
+++ b/app/src/main/java/com/example/appconejitos/RulesActivity.java
@@ -1,6 +1,8 @@
 package com.example.appconejitos;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Button;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -9,5 +11,13 @@ public class RulesActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_rules);
+
+        Button btnHome = findViewById(R.id.btnHome);
+        btnHome.setOnClickListener(v -> {
+            Intent intent = new Intent(this, StartActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(intent);
+            finish();
+        });
     }
 }

--- a/app/src/main/res/layout/activity_rules.xml
+++ b/app/src/main/res/layout/activity_rules.xml
@@ -13,4 +13,12 @@
         android:text="@string/reglas"
         android:textSize="18sp" />
 
+    <Button
+        android:id="@+id/btnHome"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/btn_inicio"
+        android:layout_marginTop="20dp"
+        android:layout_gravity="center_horizontal" />
+
 </LinearLayout>


### PR DESCRIPTION
## Summary
- add Inicio button to rules screen layout and wire to start activity

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_68c0b350e9c4832582d9136e9207ed70