### PR TITLE
Add logo placeholder on start screen

### DIFF
--- a/app/src/main/res/drawable/logo.xml
+++ b/app/src/main/res/drawable/logo.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <size android:width="262dp" android:height="117dp" />
+    <solid android:color="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/layout/activity_inicio.xml
+++ b/app/src/main/res/layout/activity_inicio.xml
@@ -4,7 +4,16 @@
     android:layout_height="match_parent"
     android:background="@drawable/fondo"
     android:orientation="vertical"
-    android:gravity="center">
+    android:gravity="center_horizontal">
+
+    <ImageView
+        android:id="@+id/imgLogo"
+        android:layout_width="262dp"
+        android:layout_height="117dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="24dp"
+        android:src="@drawable/logo"
+        android:contentDescription="@string/logo_desc" />
 
     <RadioGroup
         android:id="@+id/rgDificultad"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="nivel_dificil">Difícil</string>
     <string name="tiempo_agotado">Tiempo agotado</string>
     <string name="reglas">Haz clic en los conejos para hacerlos saltar a la piedra siguiente. Los conejos solo pueden pasar por encima de otro una vez. Mueve los que miran a la derecha a la última piedra de la izquierda y los que miran a la izquierda a la última piedra de la derecha para ganar. Planifica tus movimientos o quedarás sin opciones. Usa el botón Reiniciar para comenzar de nuevo y recuerda que el tiempo corre.</string>
+    <string name="logo_desc">Logo de la aplicación</string>
 </resources>


### PR DESCRIPTION
## Summary
- Display a 262x117 logo at the top of the start screen
- Add accessibility text and placeholder drawable for the logo

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c800ceb08325b2a2572f866a22ac